### PR TITLE
Don't emit "end" until staging write is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ var ws = blobs.createWriteStream({
   key: 'some/path/file.txt'
 })
 
-ws.write('hello world\n')
-ws.end(function() {
+ws.end('hello world\n')
+
+ws.on('end', function () {
   var rs = blobs.createReadStream({
     key: 'some/path/file.txt'
   })

--- a/index.js
+++ b/index.js
@@ -39,10 +39,20 @@ BlobStore.prototype._list = function (cb) {
 }
 
 BlobStore.prototype.createReadStream = function (opts) {
-  var name = typeof opts === 'string' ? opts : opts.key
-  var subdir = filenamePrefix(name, 7)
-  var store = this._getStore(subdir)
-  return store.createReadStream(opts)
+  var self = this
+  var t = through()
+
+  this.exists(opts, function (err, exists) {
+    if (err) return t.emit('error', err)
+    if (!exists) return t.emit('error', { notFound: true })
+
+    var name = typeof opts === 'string' ? opts : opts.key
+    var subdir = filenamePrefix(name, 7)
+    var store = self._getStore(subdir)
+    store.createReadStream(opts).pipe(t)
+  })
+
+  return t
 }
 
 BlobStore.prototype.exists = function (opts, done) {

--- a/index.js
+++ b/index.js
@@ -60,8 +60,9 @@ BlobStore.prototype.remove = function (opts, done) {
 }
 
 // TODO: opts to choose whether to use staging area
-BlobStore.prototype.createWriteStream = function (opts) {
+BlobStore.prototype.createWriteStream = function (opts, cb) {
   var self = this
+  cb = cb || noop
 
   var name = typeof opts === 'string' ? opts : (opts.name ? opts.name : opts.key)
 
@@ -80,8 +81,15 @@ BlobStore.prototype.createWriteStream = function (opts) {
     var to = path.join(self._dir, subdir, name)
 
     mkdirp(path.join(self._dir, subdir), function (err) {
-      if (err) return flush(err)
-      fs.rename(from, to, flush)
+      if (err) {
+        cb(err)
+        flush(err)
+        return
+      }
+      fs.rename(from, to, function (err) {
+        cb(err, { key: name })
+        flush(err)
+      })
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "fs-blob-store": "^5.2.1",
     "fs-walk": "0.0.1",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",


### PR DESCRIPTION
Fixes #1 

Also introduces a breaking change (removal) of an undocumented feature that allowed you to pass a callback into `createWriteStream(id, cb)` to learn when the write finished. No longer needed, since `end` will be emitted now when the write from the staging area to the destination is complete.