### PR TITLE
[breaking] Rewrite using atomic-fs-blob-store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Can now handle file keys that include subdirectories
 - Uses more robust [fs-write-stream-atomic](https://github.com/npm/fs-write-stream-atomic) for atomic writes.
 
-[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...v1.0.0
+[2.0.0]: https://github.com/noffle/safe-fs-blob-store/compare/v1.0.0...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [2.0.0]
+
+### Changed
+
+- `store._list()` is now `store.list()`
+
+### Fixed
+
+- Can now handle file keys that include subdirectories
+- Uses more robust [fs-write-stream-atomic](https://github.com/npm/fs-write-stream-atomic) for atomic writes.
+
+[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var ws = blobs.createWriteStream({
 
 ws.end('hello world\n')
 
-ws.on('end', function () {
+ws.on('finish', function () {
   var rs = blobs.createReadStream({
     key: 'some/path/file.txt'
   })

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ var ws = blobs.createWriteStream({
   key: 'some/path/file.txt'
 })
 
-ws.write('hello world\n')
-ws.end(function() {
+ws.end('hello world\n')
+
+ws.on('end', function () {
   var rs = blobs.createReadStream({
     key: 'some/path/file.txt'
   })

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ additional features:
    FAT32 has a limit of ~65,000. This module transparently manages
    subdirectories from the prefixes of given keys to avoid hitting this limit as
    quickly.
+3. Adds a `list()` method which lists the key names of all the files in the
+   media store.
 
 ## Usage
 
@@ -36,6 +38,14 @@ ws.on('finish', function () {
   rs.pipe(process.stdout)
 })
 ```
+
+## API
+
+See https://github.com/maxogden/abstract-blob-store and in addition:
+
+### store.list(cb)
+
+Calls `cb` with `err, keys`, where `keys` is an array of string key names of the files in the store.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -39,10 +39,20 @@ BlobStore.prototype._list = function (cb) {
 }
 
 BlobStore.prototype.createReadStream = function (opts) {
-  var name = typeof opts === 'string' ? opts : opts.key
-  var subdir = filenamePrefix(name, 7)
-  var store = this._getStore(subdir)
-  return store.createReadStream(opts)
+  var self = this
+  var t = through()
+
+  this.exists(opts, function (err, exists) {
+    if (err) return t.emit('error', err)
+    if (!exists) return t.emit('error', { notFound: true })
+
+    var name = typeof opts === 'string' ? opts : opts.key
+    var subdir = filenamePrefix(name, 7)
+    var store = self._getStore(subdir)
+    store.createReadStream(opts).pipe(t)
+  })
+
+  return t
 }
 
 BlobStore.prototype.exists = function (opts, done) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function getTmpname (filename) {
 function BlobStore (opts) {
   if (!(this instanceof BlobStore)) return new BlobStore(opts)
   if (typeof opts === 'string') opts = {path: opts}
-  this.subDirPrefixLen = opts.subDirPrefixLen || 7
+  this.subDirPrefixLen = opts.subDirPrefixLen || 2
   this.path = opts.path
   AtomicStore.call(this, opts)
 }

--- a/index.js
+++ b/index.js
@@ -1,36 +1,78 @@
 module.exports = BlobStore
 
-var Store = require('fs-blob-store')
+var AtomicStore = require('@digidem/atomic-fs-blob-store')
+var MurmurHash3 = require('imurmurhash')
+var inherits = require('util').inherits
 var path = require('path')
 var walk = require('fs-walk')
-var fs = require('fs')
-var mkdirp = require('mkdirp')
-var through = require('through2')
 
-function noop () {}
+var noop = function () {}
 
-function BlobStore (dir, opts) {
-  if (!(this instanceof BlobStore)) return new BlobStore(dir, opts)
+// Random (but stable) postfix used to id tmp files (so they aren't listed)
+var TMP_POSTFIX = '.tmp-gxqIdUqEoqo'
 
-  // TODO: expose whether to use subdirs opt
-  // TODO: expose subdir prefix length opt
-  // TODO: expose whether to use a 'staging' subdir
-
-  this._dir = dir
-  this._stores = {}
-}
-
-BlobStore.prototype._getStore = function (subdir) {
-  if (!this._stores[subdir]) {
-    this._stores[subdir] = Store(path.join(this._dir, subdir))
+function murmurhex () {
+  var hash = MurmurHash3('')
+  for (var ii = 0; ii < arguments.length; ++ii) {
+    hash.hash('' + arguments[ii])
   }
-  return this._stores[subdir]
+  return hash.result()
 }
 
-BlobStore.prototype._list = function (cb) {
+var invocations = 0
+function getTmpname (filename) {
+  return filename + '.' + murmurhex(__filename, process.pid, ++invocations) + TMP_POSTFIX
+}
+
+function BlobStore (opts) {
+  if (!(this instanceof BlobStore)) return new BlobStore(opts)
+  if (typeof opts === 'string') opts = {path: opts}
+  this.subDirPrefixLen = opts.subDirPrefixLen || 7
+  this.path = opts.path
+  AtomicStore.call(this, opts)
+}
+
+inherits(BlobStore, AtomicStore)
+
+BlobStore.prototype.createWriteStream = function (opts, cb) {
+  if (typeof cb !== 'function') cb = noop
+  if (typeof opts === 'string') opts = {key: opts}
+  if (opts.name && !opts.key) opts.key = opts.name
+  var originalKey = opts.key
+  opts.getTmpname = getTmpname
+  opts.key = this._insertSubDirPrefix(opts.key)
+  return AtomicStore.prototype.createWriteStream.call(this, opts, function (err, metadata) {
+    metadata.key = originalKey
+    cb(err, metadata)
+  })
+}
+
+BlobStore.prototype.createReadStream = function (key) {
+  if (key && typeof key === 'object') return this.createReadStream(key.key)
+  key = this._insertSubDirPrefix(key)
+  return AtomicStore.prototype.createReadStream.call(this, key)
+}
+
+BlobStore.prototype.exists = function (opts, cb) {
+  if (typeof opts === 'string') opts = {key: opts}
+  opts.key = this._insertSubDirPrefix(opts.key)
+  return AtomicStore.prototype.exists.call(this, opts, cb)
+}
+
+BlobStore.prototype.remove = function (opts, cb) {
+  if (typeof opts === 'string') opts = {key: opts}
+  opts.key = this._insertSubDirPrefix(opts.key)
+  return AtomicStore.prototype.remove.call(this, opts, cb)
+}
+
+BlobStore.prototype.list = function (cb) {
   var names = []
-  walk.files(this._dir, function (basedir, filename, stat, next) {
-    if (!basedir.endsWith('staging')) names.push(filename)
+  var self = this
+  walk.files(this.path, function (basedir, filename, stat, next) {
+    var key = path.relative(self.path, path.join(basedir, filename))
+    // Skip tmp files
+    if (key.endsWith(TMP_POSTFIX)) return next()
+    names.push(self._removeSubDirPrefix(key))
     next()
   }, function (err) {
     if (err && err.code === 'ENOENT') cb(null, [])
@@ -38,74 +80,19 @@ BlobStore.prototype._list = function (cb) {
   })
 }
 
-BlobStore.prototype.createReadStream = function (opts) {
-  var self = this
-  var t = through()
-
-  this.exists(opts, function (err, exists) {
-    if (err) return t.emit('error', err)
-    if (!exists) return t.emit('error', { notFound: true })
-
-    var name = typeof opts === 'string' ? opts : opts.key
-    var subdir = filenamePrefix(name, 7)
-    var store = self._getStore(subdir)
-    store.createReadStream(opts).pipe(t)
-  })
-
-  return t
+BlobStore.prototype._insertSubDirPrefix = function (key) {
+  var prefixLen = this.subDirPrefixLen
+  var parsed = path.parse(key)
+  if (parsed.name.length <= prefixLen) return key
+  var prefix = parsed.name.slice(0, prefixLen)
+  return path.join(parsed.dir, prefix, parsed.base)
 }
 
-BlobStore.prototype.exists = function (opts, done) {
-  var name = typeof opts === 'string' ? opts : opts.key
-  var subdir = filenamePrefix(name, 7)
-  var store = this._getStore(subdir)
-  return store.exists(opts, done)
-}
-
-BlobStore.prototype.remove = function (opts, done) {
-  var name = typeof opts === 'string' ? opts : opts.key
-  var subdir = filenamePrefix(name, 7)
-  var store = this._getStore(subdir)
-  return store.remove(opts, done)
-}
-
-// TODO: opts to choose whether to use staging area
-BlobStore.prototype.createWriteStream = function (opts, cb) {
-  var self = this
-  cb = cb || noop
-
-  var name = typeof opts === 'string' ? opts : (opts.name ? opts.name : opts.key)
-
-  var stagingStore = this._getStore('staging')
-  var ws = stagingStore.createWriteStream(opts)
-  var t = through(function (chunk, _, next) { next(null, chunk) }, onFlush)
-  t.pipe(ws)
-
-  return t
-
-  function onFlush (flush) {
-    var subdir = filenamePrefix(name, 7)
-
-    // write result to destination
-    var from = path.join(self._dir, 'staging', name)
-    var to = path.join(self._dir, subdir, name)
-
-    mkdirp(path.join(self._dir, subdir), function (err) {
-      if (err) {
-        cb(err)
-        flush(err)
-        return
-      }
-      fs.rename(from, to, function (err) {
-        cb(err, { key: name })
-        flush(err)
-      })
-    })
-  }
-}
-
-// String, Number -> String
-function filenamePrefix (name, prefixLen) {
-  var extLen = path.extname(name).length
-  return name.substring(0, Math.min(prefixLen, name.length - extLen))
+BlobStore.prototype._removeSubDirPrefix = function (key) {
+  var prefixLen = this.subDirPrefixLen
+  var parsed = path.parse(key)
+  if (parsed.name.length <= prefixLen) return key
+  var dirs = parsed.dir.split('/')
+  if (parsed.name.slice(0, prefixLen) !== dirs.pop()) return key
+  return path.join(dirs.join('/'), parsed.base)
 }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ BlobStore.prototype._removeSubDirPrefix = function (key) {
   var prefixLen = this.subDirPrefixLen
   var parsed = path.parse(key)
   if (parsed.name.length <= prefixLen) return key
-  var dirs = parsed.dir.split('/')
+  var dirs = parsed.dir.split(path.sep)
   if (parsed.name.slice(0, prefixLen) !== dirs.pop()) return key
-  return path.join(dirs.join('/'), parsed.base)
+  return path.join(dirs.join(path.sep), parsed.base)
 }

--- a/index.js
+++ b/index.js
@@ -60,8 +60,9 @@ BlobStore.prototype.remove = function (opts, done) {
 }
 
 // TODO: opts to choose whether to use staging area
-BlobStore.prototype.createWriteStream = function (opts) {
+BlobStore.prototype.createWriteStream = function (opts, cb) {
   var self = this
+  cb = cb || noop
 
   var name = typeof opts === 'string' ? opts : (opts.name ? opts.name : opts.key)
 
@@ -80,8 +81,15 @@ BlobStore.prototype.createWriteStream = function (opts) {
     var to = path.join(self._dir, subdir, name)
 
     mkdirp(path.join(self._dir, subdir), function (err) {
-      if (err) return flush(err)
-      fs.rename(from, to, flush)
+      if (err) {
+        cb(err)
+        flush(err)
+        return
+      }
+      fs.rename(from, to, function (err) {
+        cb(err, { key: name })
+        flush(err)
+      })
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var noop = function () {}
 
 // Random (but stable) postfix used to id tmp files (so they aren't listed)
 var TMP_POSTFIX = '.tmp-gxqIdUqEoqo'
+// Random (but stable) postfix used for subdirs
+var SUBDIR_POSTFIX = '.namespaced-qvVBOUqZFjs'
 
 function murmurhex () {
   var hash = MurmurHash3('')
@@ -85,7 +87,7 @@ BlobStore.prototype._insertSubDirPrefix = function (key) {
   var prefixLen = this.subDirPrefixLen
   var parsed = path.parse(key)
   if (parsed.name.length <= prefixLen) return key
-  var prefix = parsed.name.slice(0, prefixLen)
+  var prefix = parsed.name.slice(0, prefixLen) + SUBDIR_POSTFIX
   return path.join(parsed.dir, prefix, parsed.base)
 }
 
@@ -94,6 +96,6 @@ BlobStore.prototype._removeSubDirPrefix = function (key) {
   var parsed = path.parse(key)
   if (parsed.name.length <= prefixLen) return key
   var dirs = parsed.dir.split(path.sep)
-  if (parsed.name.slice(0, prefixLen) !== dirs.pop()) return key
+  if (!dirs.pop().endsWith(SUBDIR_POSTFIX)) return key
   return path.join(dirs.join(path.sep), parsed.base)
 }

--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ BlobStore.prototype.list = function (cb) {
   })
 }
 
+BlobStore.prototype._list = BlobStore.prototype.list
+
 BlobStore.prototype._insertSubDirPrefix = function (key) {
   var prefixLen = this.subDirPrefixLen
   var parsed = path.parse(key)

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ BlobStore.prototype.createWriteStream = function (opts, cb) {
   opts.getTmpname = getTmpname
   opts.key = this._insertSubDirPrefix(opts.key)
   return AtomicStore.prototype.createWriteStream.call(this, opts, function (err, metadata) {
+    if (err) return cb(err)
     metadata.key = originalKey
     cb(err, metadata)
   })

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
   },
   "keywords": [],
   "dependencies": {
-    "fs-blob-store": "^5.2.1",
+    "@digidem/atomic-fs-blob-store": "^5.3.0",
     "fs-walk": "0.0.1",
-    "mkdirp": "^0.5.1",
-    "through2": "^2.0.3"
+    "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",
+    "concat-stream": "^1.6.2",
+    "from2-array": "0.0.4",
     "standard": "~10.0.0",
     "tape": "~4.6.2",
     "tempy": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "fs-blob-store": "^5.2.1",
     "fs-walk": "0.0.1",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
-    "abstract-blob-store": "^3.2.0",
+    "abstract-blob-store": "3.2.0",
     "concat-stream": "^1.6.2",
     "from2-array": "0.0.4",
     "standard": "~10.0.0",

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -1,0 +1,31 @@
+var test = require('tape')
+var Readable = require('stream').Readable
+
+var common = require('./common')
+
+test('interrupted write', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var i = 0
+    var brokenReadStream = new Readable()
+    brokenReadStream._read = function () {
+      i++
+      if (i === 3) {
+        this.emit(new Error('simulated error'))
+      }
+    }
+
+    brokenReadStream.pipe(store.createWriteStream('somekey'))
+
+    setTimeout(function () {
+      store.exists('somekey', function (err, exists) {
+        if (err) return t.fail(err)
+        t.equal(exists, false)
+        common.teardown(test, store, null, function (err) {
+          t.error(err)
+          t.end()
+        })
+      })
+    }, 200)
+  })
+})

--- a/test/common.js
+++ b/test/common.js
@@ -17,3 +17,5 @@ var common = {
 
 var abstractBlobTests = require('abstract-blob-store/tests')
 abstractBlobTests(test, common)
+
+module.exports = common

--- a/test/list.js
+++ b/test/list.js
@@ -1,0 +1,79 @@
+var test = require('tape')
+var from = require('from2-array')
+var Readable = require('stream').Readable
+
+var common = require('./common')
+
+test('_list lists keys', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var filenames = ['hello.txt', 'deep/subdir/long-filename-test.js', 'subdir/filename.txt']
+    var pending = filenames.length
+    filenames.forEach(function (name) {
+      var ws = store.createWriteStream({name: name}, onWrite)
+      from([Buffer.from('foo'), Buffer.from('bar')]).pipe(ws)
+    })
+
+    function onWrite (err, obj) {
+      t.error(err)
+      t.ok(obj.key, 'blob has key')
+      if (--pending > 0) return
+      store._list(onList)
+    }
+
+    function onList (err, keys) {
+      t.error(err)
+      t.deepEqual(filenames.sort(), keys.sort(), 'keys in list are correct')
+      common.teardown(test, store, null, function (err) {
+        t.error(err)
+        t.end()
+      })
+    }
+  })
+})
+
+test('_list doesn\'t list keys from failed writes', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var filenames = ['hello.txt', 'deep/subdir/long-filename-test.js', 'subdir/filename.txt']
+    var pending = filenames.length
+    filenames.forEach(function (name) {
+      var ws = store.createWriteStream({name: name}, onWrite)
+      from([Buffer.from('foo'), Buffer.from('bar')]).pipe(ws)
+    })
+
+    function onWrite (err, obj) {
+      t.error(err)
+      t.ok(obj.key, 'blob has key')
+      if (--pending > 0) return
+
+      var i = 0
+      var brokenReadStream = new Readable()
+      brokenReadStream._read = function () {
+        i++
+        if (i === 3) {
+          this.emit(new Error('simulated error'))
+        }
+      }
+
+      brokenReadStream.pipe(store.createWriteStream('somekey'))
+
+      setTimeout(function () {
+        store.exists('somekey', function (err, exists) {
+          if (err) return t.fail(err)
+          t.equal(exists, false)
+          store._list(onList)
+        })
+      }, 200)
+    }
+
+    function onList (err, keys) {
+      t.error(err)
+      t.deepEqual(filenames.sort(), keys.sort(), 'keys in list are correct')
+      common.teardown(test, store, null, function (err) {
+        t.error(err)
+        t.end()
+      })
+    }
+  })
+})

--- a/test/list.js
+++ b/test/list.js
@@ -4,7 +4,7 @@ var Readable = require('stream').Readable
 
 var common = require('./common')
 
-test('_list lists keys', function (t) {
+test('list() lists keys', function (t) {
   common.setup(test, function (err, store) {
     t.notOk(err, 'no setup err')
     var filenames = ['hello.txt', 'deep/subdir/long-filename-test.js', 'subdir/filename.txt']
@@ -18,7 +18,7 @@ test('_list lists keys', function (t) {
       t.error(err)
       t.ok(obj.key, 'blob has key')
       if (--pending > 0) return
-      store._list(onList)
+      store.list(onList)
     }
 
     function onList (err, keys) {
@@ -32,7 +32,7 @@ test('_list lists keys', function (t) {
   })
 })
 
-test('_list doesn\'t list keys from failed writes', function (t) {
+test('list() doesn\'t list keys from failed writes', function (t) {
   common.setup(test, function (err, store) {
     t.notOk(err, 'no setup err')
     var filenames = ['hello.txt', 'deep/subdir/long-filename-test.js', 'subdir/filename.txt']
@@ -62,7 +62,7 @@ test('_list doesn\'t list keys from failed writes', function (t) {
         store.exists('somekey', function (err, exists) {
           if (err) return t.fail(err)
           t.equal(exists, false)
-          store._list(onList)
+          store.list(onList)
         })
       }, 200)
     }

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -50,7 +50,7 @@ test('reading a blob as a stream', function (t) {
 test('subdirs don\'t conflict with prefixes', function (t) {
   common.setup(test, function (err, store) {
     t.notOk(err, 'no setup err')
-    var filenames = ['foobar1filename.txt', 'foobar1', 'foobar1/filename.txt', 'foobar1/filename']
+    var filenames = ['foobar.txt', 'fo']
     var pending = filenames.length
     filenames.forEach(function (name) {
       var ws = store.createWriteStream({name: name}, onWrite)

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -87,7 +87,6 @@ test('subdirs don\'t conflict with prefixes', function (t) {
   })
 })
 
-
 test('reading a blob that does not exist', function (t) {
   common.setup(test, function (err, store) {
     t.notOk(err, 'no setup err')

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -1,0 +1,93 @@
+var test = require('tape')
+var from = require('from2-array')
+var concat = require('concat-stream')
+
+var common = require('./common')
+
+test('piping a blob into a blob write stream', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var ws = store.createWriteStream({name: 'deep/subdir/long-filename-test.js'}, function (err, obj) {
+      t.error(err)
+      t.ok(obj.key, 'blob has key')
+      common.teardown(test, store, obj, function (err) {
+        t.error(err)
+        t.end()
+      })
+    })
+    from([Buffer.from('foo'), Buffer.from('bar')]).pipe(ws)
+  })
+})
+
+test('reading a blob as a stream', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+
+    var ws = store.createWriteStream({name: 'deep/subdir/long-filename-test.js'}, function (err, blob) {
+      t.notOk(err, 'no blob write err')
+      t.ok(blob.key, 'blob has key')
+
+      var rs = store.createReadStream(blob)
+
+      rs.on('error', function (e) {
+        t.false(e, 'no read stream err')
+        t.end()
+      })
+
+      rs.pipe(concat(function (file) {
+        t.equal(file.length, 6, 'blob length is correct')
+        common.teardown(test, store, blob, function (err) {
+          t.error(err)
+          t.end()
+        })
+      }))
+    })
+
+    from([Buffer.from('foo'), Buffer.from('bar')]).pipe(ws)
+  })
+})
+
+test('reading a blob that does not exist', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+
+    var rs = store.createReadStream({name: 'deep/subdir/long-filename-test.js', key: '8843d7f92416211de9ebb963ff4ce28125932878'})
+
+    rs.on('error', function (e) {
+      t.ok(e, 'got a read stream err')
+      t.ok(e.notFound, 'error reports not found')
+      common.teardown(test, store, undefined, function (err) {
+        t.error(err)
+        t.end()
+      })
+    })
+  })
+})
+
+test('check if a blob exists', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var blobMeta = {name: 'deep/subdir/long-filename-test.js', key: '8843d7f92416211de9ebb963ff4ce28125932878'}
+    store.exists(blobMeta, function (err, exists) {
+      t.error(err)
+      t.notOk(exists, 'does not exist')
+
+      var ws = store.createWriteStream({name: 'deep/subdir/long-filename-test.js'}, function (err, obj) {
+        t.notOk(err, 'no blob write err')
+        t.ok(obj.key, 'blob has key')
+
+        // on this .exists call use the metadata from the writeStream
+        store.exists(obj, function (err, exists) {
+          t.error(err)
+          t.ok(exists, 'exists')
+          common.teardown(test, store, obj, function (err) {
+            t.error(err)
+            t.end()
+          })
+        })
+      })
+
+      from([Buffer.from('foo'), Buffer.from('bar')]).pipe(ws)
+    })
+  })
+})

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -47,6 +47,47 @@ test('reading a blob as a stream', function (t) {
   })
 })
 
+test('subdirs don\'t conflict with prefixes', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var filenames = ['foobar1filename.txt', 'foobar1', 'foobar1/filename.txt', 'foobar1/filename']
+    var pending = filenames.length
+    filenames.forEach(function (name) {
+      var ws = store.createWriteStream({name: name}, onWrite)
+      from([Buffer.from(name)]).pipe(ws)
+    })
+
+    function onWrite (err, obj) {
+      t.error(err)
+      t.ok(obj.key, 'blob has key')
+      if (--pending > 0) return
+      pending = filenames.length
+      filenames.forEach(function (name) {
+        var rs = store.createReadStream(name)
+
+        rs.on('error', function (e) {
+          t.false(e, 'no read stream err')
+          t.end()
+        })
+
+        rs.pipe(concat(function (file) {
+          t.equal(file.toString(), name, 'correct file is returned')
+          done()
+        }))
+      })
+    }
+
+    function done () {
+      if (--pending > 0) return
+      common.teardown(test, store, null, function (err) {
+        t.error(err)
+        t.end()
+      })
+    }
+  })
+})
+
+
 test('reading a blob that does not exist', function (t) {
   common.setup(test, function (err, store) {
     t.notOk(err, 'no setup err')

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -55,7 +55,7 @@ test('reading a blob that does not exist', function (t) {
 
     rs.on('error', function (e) {
       t.ok(e, 'got a read stream err')
-      t.ok(e.notFound, 'error reports not found')
+      t.equal(e.code, 'ENOENT', 'correct error code')
       common.teardown(test, store, undefined, function (err) {
         t.error(err)
         t.end()

--- a/test/read-write.js
+++ b/test/read-write.js
@@ -91,3 +91,28 @@ test('check if a blob exists', function (t) {
     })
   })
 })
+
+test('check readme example works', function (t) {
+  common.setup(test, function (err, store) {
+    t.notOk(err, 'no setup err')
+    var ws = store.createWriteStream({
+      key: 'some/path/file.txt'
+    })
+
+    ws.end('hello world\n')
+
+    ws.on('finish', function () {
+      var rs = store.createReadStream({
+        key: 'some/path/file.txt'
+      })
+
+      rs.pipe(concat(function (file) {
+        t.equal(file.toString(), 'hello world\n', 'file matches')
+        common.teardown(test, store, file, function (err) {
+          t.error(err)
+          t.end()
+        })
+      }))
+    })
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ var common = {
     cb(null, store)
   },
   teardown: function (t, store, blob, cb) {
-    rimraf.sync(store._dir)
+    rimraf.sync(store.path)
     cb()
   }
 }


### PR DESCRIPTION
This uses [atomic-fs-blob-store](https://github.com/binded/atomic-fs-blob-store) which in turn uses [fs-write-stream-atomic](https://github.com/npm/fs-write-stream-atomic) which has way more tests for broken writes, especially edge cases on windows.

I wrote more tests, which fail on the `flush` branch. This rewrite simplifies things a lot I think and should be more robust. I needed to use a fork of fs-write-stream-atomic to allow for custom names for tmp files, so that the `list()` function will work.

I also removed the `_` prefix from the `list()` function, since this is now a tested part of the API that we depend upon and should not be considered an internal function.

There are two failing tests because of a [breaking change](https://github.com/maxogden/abstract-blob-store/issues/15) that was introduced in the latest abstract-blob-store without a major version bump (not found file errors do not have a `notFound=true` property set)
